### PR TITLE
Update PersonRepo.java to allow build to succeed

### DIFF
--- a/chapter12/reactive-boot-r2dbc/src/main/java/com/apress/cems/person/PersonRepo.java
+++ b/chapter12/reactive-boot-r2dbc/src/main/java/com/apress/cems/person/PersonRepo.java
@@ -1,6 +1,6 @@
 package com.apress.cems.person;
 
-import org.springframework.data.r2dbc.repository.query.Query;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;


### PR DESCRIPTION
After installing local ojdbc7 file, removing r2dbc comments on build.gradle, I found this @Query annotation was causing the build excluding tests to fail. After this change I was able to get it to build successfully.