### PR TITLE
Update Junit 4 annotations to Junit 5.

### DIFF
--- a/chapter02/config-practice/src/test/java/com/apress/cems/config/FullConfigTest.java
+++ b/chapter02/config-practice/src/test/java/com/apress/cems/config/FullConfigTest.java
@@ -29,11 +29,12 @@ package com.apress.cems.config;
 
 import com.apress.cems.pojos.repos.DetectiveRepo;
 import com.apress.cems.pojos.repos.EvidenceRepo;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -42,7 +43,7 @@ import static org.junit.Assert.assertNotNull;
  * @since 1.0
  */
 // TODO 11. Modify this test class to use more than one configuration class
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {FullConfig.class})
 public class FullConfigTest {
 


### PR DESCRIPTION
When run alone in IntelliJ, FullConfigTest.java from chapter02 module fails with the following message: "No tests found for given includes". This is due to the fact that this test uses Junit 4 annotations. If changed to the Junit 5 Jupiter annotations, the test works as expected.

To reproduce: open the project in IntelliJ, Ctrl+N to find FullCOnfigTest class, Ctrl+Shift+F10 to run it. 
Result: The test fails.
Expected: The test succeeds.