### PR TITLE
Chapter02 - SimpleOperationsServiceTest - Incorrect order

### DIFF
--- a/chapter02/pojos-practice/src/test/java/com/apress/cems/pojos/services/SimpleOperationsServiceTest.java
+++ b/chapter02/pojos-practice/src/test/java/com/apress/cems/pojos/services/SimpleOperationsServiceTest.java
@@ -62,9 +62,9 @@ public class SimpleOperationsServiceTest extends SimpleServiceTestBase {
         person.setHiringDate(LocalDateTime.now());
         person.setPassword("123");
         var detective = detectiveService.createDetective(person, Rank.INSPECTOR);
-        detective.setBadgeNumber(BADGE_NO);
         assertNotNull(detective);
         assertEquals(DETECTIVE_ID, detective.getId());
+        detective.setBadgeNumber(BADGE_NO);
 
         // create storage entries
         var storage = new Storage();


### PR DESCRIPTION
A NullPointerException being thrown from the statement "detective.setBadgeNumber(BADGE_NO)" would make the assertion "assertNotNull(detective)" unreachable and useless.